### PR TITLE
Add extracted web UI template

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,16 @@ uzi reset
 
 **Warning**: This deletes all data in `~/.local/share/uzi`
 
+### `uzi web`
+
+Launch a simple web interface for sending prompts and viewing agent status.
+
+```bash
+uzi web --port 8080
+```
+
+Open `http://localhost:8080` in your browser and use the form to send new prompts.
+
 ### Advanced Usage
 
 **Running different AI tools:**

--- a/cmd/web/templates/index.html
+++ b/cmd/web/templates/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Uzi Web</title>
+<style>
+body { font-family: sans-serif; max-width: 800px; margin: 40px auto; padding: 20px; }
+form { margin-bottom: 20px; }
+textarea { width: 100%; font-family: monospace; }
+label { display: block; margin-top: 10px; }
+pre { background-color: #f9f9f9; padding: 10px; border: 1px solid #ddd; overflow-x: auto; }
+button { margin-top: 10px; padding: 8px 16px; }
+</style>
+</head>
+<body>
+<h1>Uzi Web</h1>
+<form action="/prompt" method="POST">
+  <label>Prompt:<br><textarea name="prompt" rows="4"></textarea></label>
+  <label>Claude agents: <input type="number" name="claude" value="3" min="1"></label>
+  <label>Codex agents: <input type="number" name="codex" value="5" min="1"></label>
+  <button type="submit">Send</button>
+</form>
+<h2>Current Sessions</h2>
+<pre>{{.LsOutput}}</pre>
+</body>
+</html>

--- a/cmd/web/web.go
+++ b/cmd/web/web.go
@@ -1,0 +1,111 @@
+package web
+
+import (
+	"context"
+	"embed"
+	"flag"
+	"fmt"
+	"html/template"
+	"net/http"
+	"os/exec"
+	"time"
+
+	"github.com/devflowinc/uzi/pkg/state"
+	"github.com/peterbourgon/ff/v3/ffcli"
+)
+
+var (
+	fs     = flag.NewFlagSet("uzi web", flag.ExitOnError)
+	port   = fs.Int("port", 8080, "port for the web server")
+	CmdWeb = &ffcli.Command{
+		Name:       "web",
+		ShortUsage: "uzi web",
+		ShortHelp:  "Run a simple web UI for uzi",
+		FlagSet:    fs,
+		Exec:       run,
+	}
+)
+
+//go:embed templates/index.html
+var indexHTML string
+
+var indexTmpl = template.Must(template.New("index.html").Parse(indexHTML))
+
+type pageData struct {
+	LsOutput string
+}
+
+func run(ctx context.Context, args []string) error {
+	http.HandleFunc("/", indexHandler)
+	http.HandleFunc("/prompt", promptHandler)
+	addr := fmt.Sprintf(":%d", *port)
+	srv := &http.Server{Addr: addr}
+	go func() {
+		<-ctx.Done()
+		srv.Shutdown(context.Background())
+	}()
+	fmt.Printf("Starting uzi web on %s\n", addr)
+	return srv.ListenAndServe()
+}
+
+func indexHandler(w http.ResponseWriter, r *http.Request) {
+	lsOutput := runUziLs()
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	indexTmpl.Execute(w, pageData{LsOutput: lsOutput})
+}
+
+func promptHandler(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	prompt := r.FormValue("prompt")
+	claude := r.FormValue("claude")
+	codex := r.FormValue("codex")
+	if claude == "" {
+		claude = "3"
+	}
+	if codex == "" {
+		codex = "5"
+	}
+	go func() {
+		runPrompt(prompt, claude, codex)
+	}()
+	http.Redirect(w, r, "/", http.StatusSeeOther)
+}
+
+func runPrompt(prompt, claude, codex string) {
+	agents := fmt.Sprintf("claude:%s,codex:%s", claude, codex)
+	cmd := exec.Command("./uzi", "prompt", "--agents", agents, prompt)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	_ = cmd.Run()
+	runAutoUntilDone()
+}
+
+func runAutoUntilDone() {
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(ctx, "./uzi", "auto")
+	if err := cmd.Start(); err != nil {
+		return
+	}
+	sm := state.NewStateManager()
+	ticker := time.NewTicker(5 * time.Second)
+	for range ticker.C {
+		sessions, _ := sm.GetActiveSessionsForRepo()
+		if len(sessions) == 0 {
+			cancel()
+			ticker.Stop()
+			cmd.Wait()
+			return
+		}
+	}
+}
+
+func runUziLs() string {
+	out, err := exec.Command("./uzi", "ls").CombinedOutput()
+	if err != nil {
+		return err.Error()
+	}
+	return string(out)
+}

--- a/uzi.go
+++ b/uzi.go
@@ -21,6 +21,7 @@ import (
 	"github.com/devflowinc/uzi/cmd/reset"
 	"github.com/devflowinc/uzi/cmd/run"
 	"github.com/devflowinc/uzi/cmd/watch"
+	"github.com/devflowinc/uzi/cmd/web"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 )
@@ -34,6 +35,7 @@ var subcommands = []*ffcli.Command{
 	checkpoint.CmdCheckpoint,
 	watch.CmdWatch,
 	broadcast.CmdBroadcast,
+	web.CmdWeb,
 }
 
 var commandAliases = map[string]*regexp.Regexp{


### PR DESCRIPTION
## Summary
- move web server HTML to templates/index.html and embed it
- serve the embedded template when running `uzi web`
- keep documentation for `uzi web`

## Testing
- `go build ./...` *(fails: no route to host)*
- `go vet ./...` *(fails: no route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683e4c787b848326b08b2fa5ab14a87b